### PR TITLE
Add an option to choose something not in the list

### DIFF
--- a/prompt-autocomplete.js
+++ b/prompt-autocomplete.js
@@ -15,6 +15,7 @@ function askQuestion () {
     var answerCallback = (typeof arguments[2] == 'function' ? arguments[2] : arguments[3]);
     var maxAutocomplete = config.maxAutocomplete || process.stdout.rows - 2;
     var highlightMode = config.highlightMode || "bright";
+    var forceToList = config.forceToList===undefined ? true : config.forceToList;
     var candidates = [];
     
     if (!promptStart) throw new Error("Prompt question is a required");
@@ -242,6 +243,13 @@ function askQuestion () {
                 charm.end();
                 process.stdin.removeListener('keypress', onKeypress);
                 answerCallback(null, candidateSubset[selectedIndex].text);
+            }
+            else if(selectedIndex==-1 && !forceToList){
+                process.stdin.setRawMode(false);
+                process.stdin.pause();
+                charm.end()
+                process.stdin.removeListener('keypress',onKeypress);
+                answerCallback(null,current)
             }
             
         } else {


### PR DESCRIPTION
var ask=require('prompt-autocomplete')
console.log('ok')
ask('To:',[
    'option1','option2','option3'
    ],{forceToList:false},function(err,answer){
        to=answer
        con()
})

Now, the user can enter new input, and not only choosing from the list.
